### PR TITLE
2.1.0 Introduce templates

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -16,7 +16,7 @@ jobs:
         platform:
           - ubuntu-latest
         python-version:
-          - 3.9
+          - '3.10'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![logo](https://github.com/rospogrigio/localtuya-homeassistant/blob/master/img/logo-small.png)
 
-### Since main dev is probably busy, I made this fork to merge some ignored PRs that I need, also I'll try to keep it up-to-date with master, so I can't promise that this fork is gonna be up-to-date all the time
+#### Since main dev is probably busy, I made this fork to merge some ignored PRs that I need, also I'll try to keep it up-to-date with master, so I can't promise that this fork is gonna be up-to-date all the time
 > Discussions are available.
 > 
 > useing this fork after ver 2 it won't be possible to install original repo above this one unless you install `1.9.0_rev` then install main repo

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -220,21 +220,20 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             hass.config_entries.async_update_entry(stored_entries[0], data=new_data)
             await hass.config_entries.async_remove(config_entry.entry_id)
     if config_entry.version == 2:
-        """ Switch config flow to selectors convert DP IDs from int to str `require HA 2022.4 ` """
+        # Switch config flow to selectors convert DP IDs from int to str require HA 2022.4.
         _LOGGER.debug("Migrating config entry from version %s", config_entry.version)
         if config_entry.entry_id == stored_entries[0].entry_id:
             new_data = stored_entries[0].data.copy()
             for device in new_data[CONF_DEVICES]:
                 i = 0
-                if new_data[CONF_DEVICES][device][CONF_ENTITIES] is not None:
-                    for _ent in new_data[CONF_DEVICES][device][CONF_ENTITIES]:
-                        ent_items = {}
-                        for k, v in _ent.items():
-                            ent_items[k] = str(v) if type(v) == type(1) else v
-                        new_data[CONF_DEVICES][device][CONF_ENTITIES][i].update(ent_items)
-                        i = i + 1
+                for _ent in new_data[CONF_DEVICES][device][CONF_ENTITIES]:
+                    ent_items = {}
+                    for k, v in _ent.items():
+                        ent_items[k] = str(v) if isinstance(v, int) else v
+                    new_data[CONF_DEVICES][device][CONF_ENTITIES][i].update(ent_items)
+                    i = i + 1
             config_entry.version = new_version
-            hass.config_entries.async_update_entry(config_entry,  data=new_data)
+            hass.config_entries.async_update_entry(config_entry, data=new_data)
 
     _LOGGER.info(
         "Entry %s successfully migrated to version %s.",

--- a/custom_components/localtuya/button.py
+++ b/custom_components/localtuya/button.py
@@ -23,14 +23,21 @@ def flow_schema(dps):
 class LocaltuyaButton(LocalTuyaEntity, ButtonEntity):
     """Representation of a Tuya button."""
 
-    def __init__(self,device,config_entry,buttonid,**kwargs,):
+    def __init__(
+        self,
+        device,
+        config_entry,
+        buttonid,
+        **kwargs,
+    ):
         """Initialize the Tuya button."""
         super().__init__(device, config_entry, buttonid, _LOGGER, **kwargs)
         self._state = None
         _LOGGER.debug("Initialized button [%s]", self.name)
 
     async def async_press(self):
-        """Press the button"""
+        """Press the button."""
         await self._device.set_dp(True, self._dp_id)
+
 
 async_setup_entry = partial(async_setup_entry, DOMAIN, LocaltuyaButton, flow_schema)

--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -133,7 +133,9 @@ def flow_schema(dps):
         vol.Optional(CONF_HVAC_MODE_DP): _col_to_select(dps, is_dps=True),
         vol.Optional(CONF_HVAC_MODE_SET): _col_to_select(list(HVAC_MODE_SETS.keys())),
         vol.Optional(CONF_HVAC_ACTION_DP): _col_to_select(dps, is_dps=True),
-        vol.Optional(CONF_HVAC_ACTION_SET): _col_to_select(list(HVAC_ACTION_SETS.keys())),
+        vol.Optional(CONF_HVAC_ACTION_SET): _col_to_select(
+            list(HVAC_ACTION_SETS.keys())
+        ),
         vol.Optional(CONF_ECO_DP): _col_to_select(dps, is_dps=True),
         vol.Optional(CONF_ECO_VALUE): str,
         vol.Optional(CONF_PRESET_DP): _col_to_select(dps, is_dps=True),

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     STATE_UNKNOWN,
+    CONF_ENTITY_CATEGORY,
     EntityCategory,
 )
 from homeassistant.core import callback
@@ -40,7 +41,6 @@ from .const import (
     DATA_CLOUD,
     DOMAIN,
     TUYA_DEVICES,
-    CONF_CATEGORY_ENTITY,
     DEFAULT_CATEGORIES,
 )
 
@@ -484,8 +484,8 @@ class LocalTuyaEntity(RestoreEntity, pytuya.ContextualLogger):
     @property
     def entity_category(self) -> str:
         """Return the category of the entity."""
-        if self.has_config(CONF_CATEGORY_ENTITY):
-            category = self._config[CONF_CATEGORY_ENTITY]
+        if self.has_config(CONF_ENTITY_CATEGORY):
+            category = self._config[CONF_ENTITY_CATEGORY]
             if EntityCategory.CONFIG in category:
                 category = EntityCategory.CONFIG
             elif EntityCategory.DIAGNOSTIC in category:

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -4,6 +4,8 @@ import logging
 import time
 from importlib import import_module
 
+from .helpers.templates import create_tuya_config, export_tuya_config, list_templates
+
 
 import homeassistant.helpers.config_validation as cv
 
@@ -23,6 +25,7 @@ from homeassistant.const import (
     CONF_DEVICES,
     CONF_ENTITIES,
     CONF_FRIENDLY_NAME,
+    CONF_ENTITY_CATEGORY,
     CONF_HOST,
     CONF_ID,
     CONF_NAME,
@@ -57,7 +60,6 @@ from .const import (
     DATA_DISCOVERY,
     DOMAIN,
     PLATFORMS,
-    CONF_CATEGORY_ENTITY,
     ENTITY_CATEGORY,
     DEFAULT_CATEGORIES,
 )
@@ -97,8 +99,10 @@ def _col_to_select(opt_list: dict, multi_select=False, is_dps=False):
 ENTRIES_VERSION = 3
 
 PLATFORM_TO_ADD = "platform_to_add"
+USE_TEMPLATE = "use_template"
+TEMPLATES = "templates"
 NO_ADDITIONAL_ENTITIES = "no_additional_entities"
-SELECTED_DEVICE = "selected_device"
+EXPORT_CONFIG = "export_config"
 
 CUSTOM_DEVICE = {"Add custom device": "..."}
 
@@ -146,6 +150,17 @@ DEVICE_SCHEMA = vol.Schema(
 
 PICK_ENTITY_SCHEMA = vol.Schema(
     {vol.Required(PLATFORM_TO_ADD, default="switch"): _col_to_select(PLATFORMS)}
+)
+
+PICK_TEMPLATE = vol.Schema(
+    {
+        vol.Required(
+            TEMPLATES,
+            default=list(list_templates().values())[0]
+            if list_templates()
+            else "No templates found.",
+        ): _col_to_select(list_templates())
+    }
 )
 
 
@@ -198,6 +213,7 @@ def options_schema(entities):
             ): cv.multi_select(entity_names),
             # _col_to_select(entity_names, multi_select=True)
             vol.Required(CONF_ENABLE_ADD_ENTITIES, default=False): bool,
+            vol.Optional(EXPORT_CONFIG, default=False): bool,
         }
     )
 
@@ -249,7 +265,7 @@ def platform_schema(platform, dps_strings, allow_id=True, yaml=False):
         schema[vol.Required(CONF_ID)] = _col_to_select(dps_strings, is_dps=True)
     schema[vol.Required(CONF_FRIENDLY_NAME)] = str
     schema[
-        vol.Required(CONF_CATEGORY_ENTITY, default=str(default_category(platform)))
+        vol.Required(CONF_ENTITY_CATEGORY, default=str(default_category(platform)))
     ] = _col_to_select(ENTITY_CATEGORY)
     return vol.Schema(schema).extend(flow_schema(platform, dps_strings))
 
@@ -488,6 +504,8 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
         self.selected_platform = None
         self.discovered_devices = {}
         self.entities = []
+        self.use_template = False
+        self.template_device = None
 
     async def async_step_init(self, user_input=None):
         """Manage basic options."""
@@ -641,6 +659,13 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_PRODUCT_NAME
                         )
                 if self.editing_device:
+                    if user_input.get(EXPORT_CONFIG):
+                        _config = self.config_entry.data[CONF_DEVICES][dev_id].copy()
+                        export_tuya_config(
+                            _config, self.device_data[CONF_FRIENDLY_NAME]
+                        )
+                        return self.async_create_entry(title="", data={})
+
                     if user_input[CONF_ENABLE_ADD_ENTITIES]:
                         self.editing_device = False
                         user_input[CONF_DEVICE_ID] = dev_id
@@ -669,7 +694,10 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
                             int(entity.split(":")[0])
                             for entity in user_input[CONF_ENTITIES]
                         ]
-                        device_config = self.config_entry.data[CONF_DEVICES][dev_id]
+                        if self.use_template:
+                            device_config = self.template_device
+                        else:
+                            device_config = self.config_entry.data[CONF_DEVICES][dev_id]
                         self.entities = [
                             entity
                             for entity in device_config[CONF_ENTITIES]
@@ -692,7 +720,11 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
         defaults = {}
         if self.editing_device:
             # If selected device exists as a config entry, load config from it
-            defaults = self.config_entry.data[CONF_DEVICES][dev_id].copy()
+            defaults = (
+                self.device_data
+                if self.use_template
+                else self.config_entry.data[CONF_DEVICES][dev_id].copy()
+            )
             cloud_devs = self.hass.data[DOMAIN][DATA_CLOUD].device_list
             placeholders = {"for_device": f" for device `{dev_id}`"}
             if dev_id in cloud_devs:
@@ -735,6 +767,25 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
             description_placeholders=placeholders,
         )
 
+    async def async_step_choose_template(self, user_input=None):
+        """Handle asking which templates to use"""
+        if user_input is not None:
+            self.use_template = True
+            filename = user_input.get(TEMPLATES)
+            _config = create_tuya_config(filename)
+            dev_conf = self.device_data
+            dev_conf[CONF_ENTITIES] = _config
+            dev_conf[CONF_DPS_STRINGS] = self.dps_strings
+            self.device_data = dev_conf
+
+            self.entities = dev_conf[CONF_ENTITIES]
+            self.template_device = self.device_data
+            self.editing_device = True
+
+            return await self.async_step_configure_device()
+        schema = PICK_TEMPLATE
+        return self.async_show_form(step_id="choose_template", data_schema=schema)
+
     async def async_step_pick_entity_type(self, user_input=None):
         """Handle asking if user wants to add another entity."""
         if user_input is not None:
@@ -757,12 +808,22 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
                 )
                 return self.async_create_entry(title="", data={})
 
+            if user_input.get(USE_TEMPLATE):
+                return await self.async_step_choose_template()
+
             self.selected_platform = user_input[PLATFORM_TO_ADD]
             return await self.async_step_configure_entity()
 
         # Add a checkbox that allows bailing out from config flow if at least one
         # entity has been added
         schema = PICK_ENTITY_SCHEMA
+        # Template only avaliable in first time adding platform
+        if (
+            not self.use_template
+            and self.selected_platform is None
+            and not self.editing_device
+        ):
+            schema = schema.extend({vol.Optional(USE_TEMPLATE, default=False): bool})
         if self.selected_platform is not None:
             schema = schema.extend(
                 {vol.Required(NO_ADDITIONAL_ENTITIES, default=True): bool}
@@ -785,7 +846,7 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
         errors = {}
         if user_input is not None:
             entity = strip_dps_values(user_input, self.dps_strings)
-            entity[CONF_ID] = int(self.current_entity[CONF_ID])
+            entity[CONF_ID] = self.current_entity[CONF_ID]
             entity[CONF_PLATFORM] = self.current_entity[CONF_PLATFORM]
             self.device_data[CONF_ENTITIES].append(entity)
             if len(self.entities) == len(self.device_data[CONF_ENTITIES]):

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -20,7 +20,6 @@ PLATFORMS = [
     "switch",
     "vacuum",
 ]
-
 TUYA_DEVICES = "tuya_devices"
 
 ATTR_CURRENT = "current"
@@ -142,14 +141,14 @@ CONF_RESTORE_ON_RECONNECT = "restore_on_reconnect"
 
 # Categories
 ENTITY_CATEGORY = {
-    "Controls" : None,
-    "Configuration" : EntityCategory.CONFIG,
-    "Diagnostic" : EntityCategory.DIAGNOSTIC
+    "Controls": None,
+    "Configuration": EntityCategory.CONFIG,
+    "Diagnostic": EntityCategory.DIAGNOSTIC,
 }
 
 # Default Categories
 DEFAULT_CATEGORIES = {
-    "CONTROL" : ['switch', 'climate','fan','vacuum','light'],
-    "CONFIG" : ['select','number','button'],
-    "DIAGNOSTIC" : ['sensor','binary_sensor']
+    "CONTROL": ["switch", "climate", "fan", "vacuum", "light"],
+    "CONFIG": ["select", "number", "button"],
+    "DIAGNOSTIC": ["sensor", "binary_sensor"],
 }

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -48,7 +48,6 @@ CONF_MANUAL_DPS = "manual_dps_strings"
 CONF_DEFAULT_VALUE = "dps_default_value"
 CONF_RESET_DPIDS = "reset_dpids"
 CONF_PASSIVE_ENTITY = "is_passive_entity"
-CONF_CATEGORY_ENTITY = "device_category"
 
 # light
 CONF_BRIGHTNESS_LOWER = "brightness_lower"

--- a/custom_components/localtuya/helpers/templates.py
+++ b/custom_components/localtuya/helpers/templates.py
@@ -1,0 +1,66 @@
+""" Parse templates. """
+import logging
+import os.path
+import yaml
+
+from fnmatch import fnmatch
+from homeassistant.util.yaml import load_yaml
+
+
+from homeassistant.const import CONF_PLATFORM, CONF_ENTITIES
+import custom_components.localtuya.templates as templates_dir
+
+JSON_TYPE = list | dict | str
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def list_templates():
+    dir = os.path.dirname(templates_dir.__file__)
+    files = {}
+    for p, d, f in os.walk(dir):
+        for file in sorted(f):
+            if fnmatch(file, "*yaml") or fnmatch(file, "*yml"):
+                fn = str(file).replace(".yaml", "").replace("_", " ")
+                files[fn.capitalize()] = file
+    return files
+
+
+def create_tuya_config(filename):
+    template_dir = os.path.dirname(templates_dir.__file__)
+    template_file = os.path.join(template_dir, filename)
+    _config = load_yaml(template_file)
+    entity = []
+    for cfg in _config:
+        ent = {}
+        for plat, values in cfg.items():
+            for key, value in values.items():
+                ent[str(key)] = (
+                    str(value)
+                    if not isinstance(value, bool) and not isinstance(value, float)
+                    else value
+                )
+            ent[CONF_PLATFORM] = plat
+        entity.append(ent)
+    return entity
+
+
+def export_tuya_config(config, config_name):
+    export_config = []
+    for cfg in config[CONF_ENTITIES]:
+        ents = {cfg[CONF_PLATFORM]: cfg}
+        export_config.append(ents)
+    fname = config_name + ".yaml" if not config_name.endswith(".yaml") else config_name
+    fname = fname.replace(" ", "_")
+    template_dir = os.path.dirname(templates_dir.__file__)
+    template_file = os.path.join(template_dir, fname)
+    _config = yaml_dump(export_config, template_file)
+
+
+def yaml_dump(config, fname: str | None = None) -> JSON_TYPE:
+    """Load a YAML file."""
+    try:
+        with open(fname, "w", encoding="utf-8") as conf_file:
+            return yaml.dump(config, conf_file)
+    except UnicodeDecodeError as exc:
+        _LOGGER.error("Unable to read file %s: %s", fname, exc)

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -172,10 +172,17 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         self._effect_list = []
         self._scenes = None
         if self.has_config(CONF_SCENE):
-            if (self.has_config(CONF_SCENE_VALUES) and
-                self.has_config(CONF_SCENE_VALUES_FRIENDLY)):
-                values_list = [value.strip() for value in self._config.get(CONF_SCENE_VALUES).split(";")]
-                friendly_values_list = [value.strip() for value in self._config.get(CONF_SCENE_VALUES_FRIENDLY).split(";")]
+            if self.has_config(CONF_SCENE_VALUES) and self.has_config(
+                CONF_SCENE_VALUES_FRIENDLY
+            ):
+                values_list = [
+                    value.strip()
+                    for value in self._config.get(CONF_SCENE_VALUES).split(";")
+                ]
+                friendly_values_list = [
+                    value.strip()
+                    for value in self._config.get(CONF_SCENE_VALUES_FRIENDLY).split(";")
+                ]
                 self._scenes = dict(zip(friendly_values_list, values_list))
             elif self._config.get(CONF_SCENE) < 20:
                 self._scenes = SCENE_LIST_RGBW_255

--- a/custom_components/localtuya/templates/sample_2g_switch.yaml
+++ b/custom_components/localtuya/templates/sample_2g_switch.yaml
@@ -1,0 +1,43 @@
+# Simple 2 Switches config example
+- switch:
+    id: "1"
+    friendly_name: "2G Local Switch 1"
+    entity_category: "controls"
+    restore_on_reconnect: false
+    is_passive_entity: false
+    platform: "switch"
+
+- switch:
+    id: "2"
+    friendly_name: "2G Local Switch 2"
+    entity_category: "controls"
+    is_passive_entity: false
+    platform: "switch"
+####################################################
+#---#             Templates Guide              #---#
+####################################################
+# Templates:
+# The template is basically ready to go configs can be imported instead of choosing configs DPs names etc...
+
+# IMPORTANT:
+# there is now valid check atm config so make sure you're importing correct configs.
+
+# the configs depends on the platform and what input does platform support read bottom.
+
+# THERE Is 2 ways to make template:
+# - 1st is write the yaml ur self:
+# --[ Keep in mind there is no valid check atm ]
+
+# - 2st is to export ur device file from config flow. [ Recommended ]:
+# -- in HA Dashboard go to [ Devices -> localtuya -> Configure -> Edit Device * choose the device u want to export
+# --- Export the device config then submit]
+
+# Templates DIR:
+#   the configs will be exported in [custom_components/localtuya/templates]
+
+# How to import:
+# -- When u add new device when the form [ Pick Entity type selection ]
+# --- Import template Form will show up showing avaliable templates in templates folder.
+
+# -- templates in [custom_components/localtuya/templates]
+# -- Templates files will load up with HA so adding files will require restarting HA to show up.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ mypy==0.901
 pydocstyle==6.1.1
 pylint==2.8.2
 pylint-strict-informational==0.1
-homeassistant==2021.12.10
+homeassistant==2023.05.0


### PR DESCRIPTION
## Templates

```yaml
Templates:
The template is basically ready to go configs can be imported instead of choosing configs DPs names etc...

IMPORTANT: 
there is now valid check atm config so make sure you're importing correct configs.

the configs depends on the platform and what input does platform support read bottom.

THERE Is 2 ways to make template:
- 1st is write the yaml ur self:
    [ Keep in mind there is no valid check atm ]

- 2st is to export ur device file from config flow. [ Recommended ]:
    in HA Dashboard go to [ Devices -> localtuya -> Configure -> Edit Device * choose the device u want to export
    Export the device config then submit]

Templates DIR:
  the configs will be exported in [custom_components/localtuya/templates]

How to import:
-- When u add new device when the form [ Pick Entity type selection ]
    Import template Form will show up showing avaliable templates in templates folder.

-- templates in [custom_components/localtuya/templates] 
    Templates files will load up with HA so adding files will require restarting HA to show up.
```

Examples:

<details><summary>2 Gang Switch</summary>
<p>

> Template [ 2 Gang Switch ] will import configs 2 entities switches:

```yaml
- switch:
    id: "1"
    friendly_name: "2G Local Switch 1"
    entity_category: "controls"
    restore_on_reconnect: false
    is_passive_entity: false
    platform: "switch"

- switch:
    id: "2"
    friendly_name: "2G Local Switch 2"
    entity_category: "controls"
    is_passive_entity: false
    platform: "switch"
```

</p>
</details> 

<details><summary>Exported Cover template</summary>
<p>

```yaml
- cover:
    commands_set: open_close_stop
    current_position_dp: '3'
    entity_category: None
    friendly_name: My BedRoom Shade
    id: '1'
    platform: cover
    position_inverted: false
    positioning_mode: position
    set_position_dp: '2'
    span_time: 25.0
- select:
    entity_category: config
    friendly_name: My BedRoom Shade Motor Direction
    id: '5'
    is_passive_entity: false
    platform: select
    restore_on_reconnect: false
    select_options: forward;back
    select_options_friendly: Forward;Reverse
- select:
    entity_category: config
    friendly_name: My BedRoom Shade Motor Mode
    id: '106'
    is_passive_entity: false
    platform: select
    restore_on_reconnect: false
    select_options: contiuation;point
    select_options_friendly: Auto;Manual
- binary_sensor:
    entity_category: diagnostic
    device_class: problem
    friendly_name: My BedRoom Shade Fault
    id: '12'
    platform: binary_sensor
    state_off: '0'
    state_on: '1'

```


</p>
</details> 

![blind_template_ex](https://github.com/xZetsubou/localtuya/assets/46300268/084d8784-df8b-4187-ae67-711e9aac4821)

